### PR TITLE
Modify home() function to be "direct" (without animation)

### DIFF
--- a/modules/commonjs/ti-window-stack/1.0.1/ti-window-stack.js
+++ b/modules/commonjs/ti-window-stack/1.0.1/ti-window-stack.js
@@ -97,23 +97,52 @@ function WindowStack() {
 		that.close(_window);
 	};
 
-	this.home = function() {
+	/**
+	 * By default, closes all the windows, one after the other, starting for the current window.
+	 * User sees all the windows getting closed.
+	 * Can be called using:
+	 * 		Alloy.Globals.windowStack.home(); // animated is true by default
+	 * 		Alloy.Globals.windowStack.home({ animated: true }); // same as above
+	 * 		Alloy.Globals.windowStack.home({ animated: false });
+	 *
+	 * @param  bool _direct Closes all other windows except the last one (so users don't see the
+	 *                      other windows getting closed) and finally closes the current window.
+	 * @return void
+	 */
+	this.home = function(_params) {
+		_params = _params || { animated: true };
+		
 		var lastLength = windows.length,
-			interval;
+		    interval;
 
-		Alloy.Globals.homeInterval = interval = setInterval(function() {
-			if (lastLength === windows.length) {
-				Alloy.Globals.windowStack.back();
-				lastLength--;
-
-				if (lastLength === 0 ||
-					// Center window is actually view on Android
-					windows[lastLength - 1].apiName === 'View') {
-
-					clearInterval(Alloy.Globals.homeInterval);
+		if (_params.animated) {
+			Alloy.Globals.homeInterval = interval = setInterval(function() {
+				if (lastLength === windows.length) {
+					Alloy.Globals.windowStack.back();
+					lastLength--;
+	
+					if (lastLength === 0 ||
+						// Center window is actually view on Android
+						windows[lastLength - 1].apiName === 'View') {
+	
+						clearInterval(Alloy.Globals.homeInterval);
+					}
 				}
-			}
-		}, 100);
+			}, 100);
+		} else {
+			var lastWindow = _.last(windows);
+            var rest       = _.without(windows, lastWindow);
+
+            rest.forEach(function(window, index){
+            	// Center window is actually view on Android
+                if (index === 0 && window.apiName === 'Ti.UI.View') {
+					return;
+				}
+				that.close(window);
+            });
+            // Closes current visible window at last
+			that.close(lastWindow);
+		}
 	};
 
 	// Close all screens, close the navigationWindow


### PR DESCRIPTION
Adding the ability to come back to the home screen without having to see all the animations closing each window.
Tested under iOS. Should work with Android.
